### PR TITLE
[Feat] VehicleLayout 컴포넌트 구현

### DIFF
--- a/components/domain/vehicle/VehicleLayout/index.tsx
+++ b/components/domain/vehicle/VehicleLayout/index.tsx
@@ -1,0 +1,17 @@
+import * as styles from './styles.css'
+
+interface VehicleLayoutProps {
+    imageUrl: React.ReactNode
+    children: React.ReactNode
+}
+
+const VehicleLayout = ({ imageUrl, children }: VehicleLayoutProps) => {
+    return (
+        <div className={styles.container}>
+            <div className={styles.imageUrlWrapper}>{imageUrl}</div>
+            <div className={styles.childrenWrapper}>{children}</div>
+        </div>
+    )
+}
+
+export default VehicleLayout

--- a/components/domain/vehicle/VehicleLayout/styles.css.ts
+++ b/components/domain/vehicle/VehicleLayout/styles.css.ts
@@ -1,0 +1,23 @@
+import { style } from '@vanilla-extract/css'
+
+import { styles } from '@/styles/theme.css'
+
+export const container = style({
+    position: 'relative',
+    width: '100%',
+    height: '100%',
+    overflow: 'hidden',
+})
+
+export const imageUrlWrapper = style({
+    width: '100%',
+    height: '250px',
+    backgroundColor: styles.colors.gray[200],
+})
+
+export const childrenWrapper = style({
+    width: '100%',
+    borderRadius: '30px 30px 0 0',
+    backgroundColor: styles.colors.white,
+    marginTop: '-20px',
+})


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
closes #58 
<!-- 이슈 지울때 작성해 주세요. -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- closes #issue-number -->

## 📋 작업 내용

차량 정보를 보여주는 레이아웃 컴포넌트 구현.

## ❓ 구현 중 고민 사항

### 레이아웃 컴포넌트 내부에서 버튼을 받을지, 페이지에서 구현할지?
> 인쇄/삭제는 페이지의 핵심 기능이며, 레이아웃 컴포넌트는 순수하게 레이아웃 역할만 담당하도록 하는 게 
좋다는 생각이 들어 페이지에서 버튼을 구현하기로 결정했습니다:)

## 🔧 변경 사항

- [x] 💡 비즈니스 로직 (src/, app/ 등)
- [ ] 📦 의존성 (package.json)
- [ ] 📃 문서 (README.md 등)
- [ ] 🔥 삭제된 파일/코드
- [ ] ⚙️ 설정 파일 (.env, .gitignore 등)

## 📸 스크린샷

<img width="1055" alt="스크린샷 2025-01-12 오후 9 23 36" src="https://github.com/user-attachments/assets/0824e18a-8f81-4000-9ce2-ee964075a3d4" />

## 📄 기타

- children prop으로 컨텐츠를 받아 유연하게 사용할 수 있도록 구현했습니다.
- 향후 차량 타입에 따른 이미지 변경 기능이 추가될 예정입니다.