### PR TITLE
[Feat] 위치조회 > 클러스터링 API 연동 및 기능구현

### DIFF
--- a/app/(main)/location/components/MapSection/index.tsx
+++ b/app/(main)/location/components/MapSection/index.tsx
@@ -34,6 +34,7 @@ const MapSection = ({ mapState, vehicleInfo, isVehicleMarkerVisible, onVehicleCl
         // console.log(currentMapState)
         const getClusterInfo = async () => {
             await clusterService.getClusteringInfo(currentMapState)
+            // await clusterService.getClusteringDetailInfo(currentMapState)
         }
         getClusterInfo()
     }, [currentMapState])

--- a/app/(main)/location/components/MapSection/index.tsx
+++ b/app/(main)/location/components/MapSection/index.tsx
@@ -7,6 +7,7 @@ import CustomMarker from '@/app/(main)/location/components/CustomMarker'
 import VehicleMarker from '@/app/(main)/location/components/VehicleMarker'
 import Map from '@/components/domain/map/Map'
 import { useMapStatus } from '@/hooks/useCurrentMapStatus'
+import { clusterService } from '@/lib/apis/cluster'
 import ClusteringData from '@/mock/clustering.json'
 import { LatLng } from '@/types/location'
 import { MapState } from '@/types/map'
@@ -30,7 +31,11 @@ const MapSection = ({ mapState, vehicleInfo, isVehicleMarkerVisible, onVehicleCl
     })
 
     useEffect(() => {
-        console.log(currentMapState)
+        // console.log(currentMapState)
+        const getClusterInfo = async () => {
+            await clusterService.getClusteringInfo(currentMapState)
+        }
+        getClusterInfo()
     }, [currentMapState])
 
     return (

--- a/app/(main)/location/components/MapSection/index.tsx
+++ b/app/(main)/location/components/MapSection/index.tsx
@@ -1,21 +1,16 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { CustomOverlayMap } from 'react-kakao-maps-sdk'
 
 import CustomMarker from '@/app/(main)/location/components/CustomMarker'
 import VehicleMarker from '@/app/(main)/location/components/VehicleMarker'
 import Map from '@/components/domain/map/Map'
+import { getCurrentMapStatus } from '@/lib/utils/map'
 import ClusteringData from '@/mock/clustering.json'
 import { LatLng } from '@/types/location'
 import { MapState } from '@/types/map'
 import { VehicleInfoModel } from '@/types/vehicle'
-
-// export interface MapStatusModel {
-//     level: number
-//     swCoord: LatLng
-//     neCoord: LatLng
-// }
 
 interface MapSectionProps {
     mapState: MapState
@@ -29,31 +24,13 @@ const MapSection = ({ mapState, vehicleInfo, isVehicleMarkerVisible, onVehicleCl
     const [isMapLoaded, setIsMapLoaded] = useState(false)
     const mapRef = useRef<kakao.maps.Map>(null)
 
-    useEffect(() => {
-        const getInfo = () => {
-            if (!isMapLoaded || !mapRef.current) return
-            const map = mapRef.current
-
-            if (!map) return
-
-            // const level = map.getLevel()
-
-            // const bounds = map.getBounds()
-            // const swLat = bounds.getSouthWest()
-            // const swLng = bounds.getSouthWest().getLng()
-            // const neLat = bounds.getNorthEast().getLat()
-            // const neLng = bounds.getNorthEast().getLng()
-
-            // console.log(`level: ${level}`)
-            // console.log(`swLat: ${swLat}, swLng: ${swLng}, neLat: ${neLat}, neLng: ${neLng}`)
-        }
-        getInfo()
-    }, [isMapLoaded, mapRef])
-
-    // const handleZoomChanged = (level: number) => {
     const handleZoomChanged = () => {
-        const level = mapRef?.current?.getLevel()
-        console.log(level)
+        if (!isMapLoaded || !mapRef.current) return
+
+        const map = mapRef.current
+        const currentMapStatus = getCurrentMapStatus(map)
+
+        console.log(currentMapStatus)
     }
 
     return (
@@ -65,7 +42,6 @@ const MapSection = ({ mapState, vehicleInfo, isVehicleMarkerVisible, onVehicleCl
             onZoomChanged={handleZoomChanged}
         >
             {ClusteringData.result.map((loc, index) => {
-                // console.log(mapState.center, mapState.level)
                 return (
                     <CustomOverlayMap key={index} position={loc.coordinate}>
                         <CustomMarker count={loc.count} onClick={() => onClick(loc.coordinate, mapState.level - 1)} />

--- a/app/(main)/location/components/MapSection/index.tsx
+++ b/app/(main)/location/components/MapSection/index.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { CustomOverlayMap } from 'react-kakao-maps-sdk'
 
 import CustomMarker from '@/app/(main)/location/components/CustomMarker'
 import VehicleMarker from '@/app/(main)/location/components/VehicleMarker'
 import Map from '@/components/domain/map/Map'
-import { getCurrentMapStatus } from '@/lib/utils/map'
+import { useMapStatus } from '@/hooks/useCurrentMapStatus'
 import ClusteringData from '@/mock/clustering.json'
 import { LatLng } from '@/types/location'
 import { MapState } from '@/types/map'
@@ -24,14 +24,14 @@ const MapSection = ({ mapState, vehicleInfo, isVehicleMarkerVisible, onVehicleCl
     const [isMapLoaded, setIsMapLoaded] = useState(false)
     const mapRef = useRef<kakao.maps.Map>(null)
 
-    const handleZoomChanged = () => {
-        if (!isMapLoaded || !mapRef.current) return
+    const { currentMapState, updateMapStatus } = useMapStatus({
+        isMapLoaded,
+        map: mapRef.current,
+    })
 
-        const map = mapRef.current
-        const currentMapStatus = getCurrentMapStatus(map)
-
-        console.log(currentMapStatus)
-    }
+    useEffect(() => {
+        console.log(currentMapState)
+    }, [currentMapState])
 
     return (
         <Map
@@ -39,7 +39,7 @@ const MapSection = ({ mapState, vehicleInfo, isVehicleMarkerVisible, onVehicleCl
             center={mapState.center}
             zoom={mapState.level}
             onLoad={() => setIsMapLoaded(true)}
-            onMapStatusChanged={handleZoomChanged}
+            onMapStatusChanged={updateMapStatus}
         >
             {ClusteringData.result.map((loc, index) => {
                 return (

--- a/app/(main)/location/components/MapSection/index.tsx
+++ b/app/(main)/location/components/MapSection/index.tsx
@@ -11,6 +11,12 @@ import { LatLng } from '@/types/location'
 import { MapState } from '@/types/map'
 import { VehicleInfoModel } from '@/types/vehicle'
 
+// export interface MapStatusModel {
+//     level: number
+//     swCoord: LatLng
+//     neCoord: LatLng
+// }
+
 interface MapSectionProps {
     mapState: MapState
     vehicleInfo: VehicleInfoModel
@@ -21,7 +27,6 @@ interface MapSectionProps {
 
 const MapSection = ({ mapState, vehicleInfo, isVehicleMarkerVisible, onVehicleClick, onClick }: MapSectionProps) => {
     const [isMapLoaded, setIsMapLoaded] = useState(false)
-
     const mapRef = useRef<kakao.maps.Map>(null)
 
     useEffect(() => {
@@ -31,21 +36,23 @@ const MapSection = ({ mapState, vehicleInfo, isVehicleMarkerVisible, onVehicleCl
 
             if (!map) return
 
-            const level = map.getLevel()
+            // const level = map.getLevel()
 
-            const bounds = map.getBounds()
-            const swLat = bounds.getSouthWest()
-            const swLng = bounds.getSouthWest().getLng()
-            const neLat = bounds.getNorthEast().getLat()
-            const neLng = bounds.getNorthEast().getLng()
+            // const bounds = map.getBounds()
+            // const swLat = bounds.getSouthWest()
+            // const swLng = bounds.getSouthWest().getLng()
+            // const neLat = bounds.getNorthEast().getLat()
+            // const neLng = bounds.getNorthEast().getLng()
 
-            console.log(`level: ${level}`)
-            console.log(`swLat: ${swLat}, swLng: ${swLng}, neLat: ${neLat}, neLng: ${neLng}`)
+            // console.log(`level: ${level}`)
+            // console.log(`swLat: ${swLat}, swLng: ${swLng}, neLat: ${neLat}, neLng: ${neLng}`)
         }
         getInfo()
     }, [isMapLoaded, mapRef])
 
-    const handleZoomChanged = (level: number) => {
+    // const handleZoomChanged = (level: number) => {
+    const handleZoomChanged = () => {
+        const level = mapRef?.current?.getLevel()
         console.log(level)
     }
 

--- a/app/(main)/location/components/MapSection/index.tsx
+++ b/app/(main)/location/components/MapSection/index.tsx
@@ -39,7 +39,7 @@ const MapSection = ({ mapState, vehicleInfo, isVehicleMarkerVisible, onVehicleCl
             center={mapState.center}
             zoom={mapState.level}
             onLoad={() => setIsMapLoaded(true)}
-            onZoomChanged={handleZoomChanged}
+            onMapStatusChanged={handleZoomChanged}
         >
             {ClusteringData.result.map((loc, index) => {
                 return (

--- a/components/domain/map/Map/index.tsx
+++ b/components/domain/map/Map/index.tsx
@@ -1,56 +1,47 @@
 'use client'
 
 import { memo } from 'react'
-import { Map as KakaoMap } from 'react-kakao-maps-sdk'
+import { Map as KakaoMap, ZoomControl } from 'react-kakao-maps-sdk'
 
 import { useKakaoLoader } from '@/hooks/useKakaoLoader'
 import { LatLng } from '@/types/location'
 
 interface MapProps {
+    ref?: React.RefObject<kakao.maps.Map>
     center?: LatLng
     zoom?: number
-    ref?: React.RefObject<kakao.maps.Map>
     children?: React.ReactNode
     onLoad?: (isMapLoaded: boolean) => void
-    onZoomChanged?: (level: number) => void
+    onZoomChanged?: () => void
 }
 
 const Map = memo(
-    ({
-        ref,
-        center = { lat: 37.5665, lng: 126.978 },
-        zoom = 10,
-        children,
-        onLoad,
-        onZoomChanged,
-        ...props
-    }: MapProps) => {
+    ({ ref, center = { lat: 37.5665, lng: 126.978 }, zoom = 10, children, onLoad, onZoomChanged }: MapProps) => {
         const { loading, error } = useKakaoLoader()
 
         const handleCreate = () => {
-            console.log('맵 생성 시점:', ref)
             onLoad?.(true)
         }
 
-        // useEffect(() => {
-        //     if (!loading && !error) {
-        //         console.log('a')
-        //         console.log(mapRef)
-        //         // console.log('loaded!!')
-        //         onLoad?.(true)
-        //     }
-        // }, [loading, error, mapRef, onLoad])
-        // useEffect(() => {
-        //     // KakaoMap 컴포넌트의 onLoad 이벤트를 이용s
-        //     if (!loading && !error && mapRef.current) {
-        //         console.log(mapRef) // 이제 맵 인스턴스가 존재함
-        //         onLoad?.(true)
-        //     }
-        // }, [loading, error, ref, onLoad])
-
         const handleZoomChanged = (map: kakao.maps.Map) => {
-            const currentZoom = map.getLevel()
-            onZoomChanged?.(currentZoom)
+            const level = map.getLevel()
+            const bounds = map.getBounds()
+            const swLat = bounds.getSouthWest().getLat()
+            const swLng = bounds.getSouthWest().getLng()
+            const neLat = bounds.getNorthEast().getLat()
+            const neLng = bounds.getNorthEast().getLng()
+
+            const swCoord = { swLat, swLng }
+            const neCoord = { neLat, neLng }
+            console.log(level, swCoord, neCoord)
+
+            // const currentMapStatus = {
+            //     level,
+            //     swCoord,
+            //     neCoord,
+            // }
+
+            onZoomChanged?.()
         }
 
         if (loading) return <div>지도를 불러오는 중...</div>
@@ -63,11 +54,10 @@ const Map = memo(
                 level={zoom}
                 style={{ width: '100%', height: '100%' }}
                 onZoomChanged={handleZoomChanged}
-                // onLoad={handleCreate}
                 onCreate={handleCreate}
-                {...props}
             >
                 {children}
+                <ZoomControl />
             </KakaoMap>
         )
     },

--- a/components/domain/map/Map/index.tsx
+++ b/components/domain/map/Map/index.tsx
@@ -12,19 +12,19 @@ interface MapProps {
     zoom?: number
     children?: React.ReactNode
     onLoad?: (isMapLoaded: boolean) => void
-    onZoomChanged?: () => void
+    onMapStatusChanged?: () => void
 }
 
 const Map = memo(
-    ({ ref, center = { lat: 37.5665, lng: 126.978 }, zoom = 10, children, onLoad, onZoomChanged }: MapProps) => {
+    ({ ref, center = { lat: 37.5665, lng: 126.978 }, zoom = 10, children, onLoad, onMapStatusChanged }: MapProps) => {
         const { loading, error } = useKakaoLoader()
 
         const handleCreate = () => {
             onLoad?.(true)
         }
 
-        const handleZoomChanged = () => {
-            onZoomChanged?.()
+        const handleMapStatusChange = () => {
+            onMapStatusChanged?.()
         }
 
         if (loading) return <div>지도를 불러오는 중...</div>
@@ -36,8 +36,9 @@ const Map = memo(
                 center={center}
                 level={zoom}
                 style={{ width: '100%', height: '100%' }}
-                onZoomChanged={handleZoomChanged}
                 onCreate={handleCreate}
+                onZoomChanged={handleMapStatusChange}
+                onDragEnd={handleMapStatusChange}
             >
                 {children}
                 <ZoomControl />

--- a/components/domain/map/Map/index.tsx
+++ b/components/domain/map/Map/index.tsx
@@ -23,24 +23,7 @@ const Map = memo(
             onLoad?.(true)
         }
 
-        const handleZoomChanged = (map: kakao.maps.Map) => {
-            const level = map.getLevel()
-            const bounds = map.getBounds()
-            const swLat = bounds.getSouthWest().getLat()
-            const swLng = bounds.getSouthWest().getLng()
-            const neLat = bounds.getNorthEast().getLat()
-            const neLng = bounds.getNorthEast().getLng()
-
-            const swCoord = { swLat, swLng }
-            const neCoord = { neLat, neLng }
-            console.log(level, swCoord, neCoord)
-
-            // const currentMapStatus = {
-            //     level,
-            //     swCoord,
-            //     neCoord,
-            // }
-
+        const handleZoomChanged = () => {
             onZoomChanged?.()
         }
 

--- a/components/domain/map/Map/index.tsx
+++ b/components/domain/map/Map/index.tsx
@@ -3,6 +3,7 @@
 import { memo } from 'react'
 import { Map as KakaoMap, ZoomControl } from 'react-kakao-maps-sdk'
 
+import { ZOOM_LEVEL } from '@/constants/map'
 import { useKakaoLoader } from '@/hooks/useKakaoLoader'
 import { LatLng } from '@/types/location'
 
@@ -35,6 +36,8 @@ const Map = memo(
                 ref={ref}
                 center={center}
                 level={zoom}
+                maxLevel={ZOOM_LEVEL.MAX}
+                minLevel={ZOOM_LEVEL.MIN}
                 style={{ width: '100%', height: '100%' }}
                 onCreate={handleCreate}
                 onZoomChanged={handleMapStatusChange}

--- a/constants/map.ts
+++ b/constants/map.ts
@@ -1,16 +1,26 @@
 export const ZOOM_LEVEL = {
+    // TODO: 범용성 고려
     INITIAL: 12,
     ROUTE: 8,
     SINGLE_VEHICLE: 7,
+    MAX: 4,
+    MIN: 13,
 } as const
 
 export const INITIAL_MAP_STATE = {
+    // MAP_BOUNDS와 통합 고려
     center: {
         lat: 36.5,
         lng: 127.5,
     },
-    // level: ZOOM_LEVEL.INITIAL,
     level: ZOOM_LEVEL.INITIAL,
+}
+
+export const MAP_BOUNDS = {
+    SW_LAT: 32.565491,
+    SW_LNG: 120.637522,
+    NE_LAT: 38.875321,
+    NE_LNG: 135.513156,
 }
 
 export const MARKER_IMAGE = {

--- a/hooks/useCurrentMapStatus.ts
+++ b/hooks/useCurrentMapStatus.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react'
+
+import { getCurrentMapStatus } from '@/lib/utils/map'
+import { MapState } from '@/types/map'
+
+export const useCurrentMapStatus = () => {
+    const [currentMapState, setCurrentMapState] = useState<MapState>({
+        level: 7,
+        swCoord: null,
+        neCoord: null,
+    })
+
+    const handleMapChange = (map: kakao.maps.Map) => {
+        const newMapStatus = getCurrentMapStatus(map)
+        setCurrentMapState(newMapStatus)
+    }
+
+    return { currentMapState, handleMapChange }
+}

--- a/hooks/useCurrentMapStatus.ts
+++ b/hooks/useCurrentMapStatus.ts
@@ -4,12 +4,7 @@ import { INITIAL_MAP_STATE } from '@/constants/map'
 import { getBoundedMapStatus } from '@/lib/utils/map'
 import { MapState } from '@/types/map'
 
-interface UseMapStatusProps {
-    isMapLoaded: boolean
-    map: kakao.maps.Map | null
-}
-
-export const useMapStatus = ({ isMapLoaded, map }: UseMapStatusProps) => {
+export const useMapStatus = (map: kakao.maps.Map | null) => {
     const [currentMapState, setCurrentMapState] = useState<MapState>({
         level: 7,
         center: INITIAL_MAP_STATE.center,
@@ -18,8 +13,7 @@ export const useMapStatus = ({ isMapLoaded, map }: UseMapStatusProps) => {
     })
 
     const updateMapStatus = () => {
-        if (!isMapLoaded || !map) return
-        // setCurrentMapState(getCurrentMapStatus(map))
+        if (!map) return
         setCurrentMapState(getBoundedMapStatus(map))
     }
 

--- a/hooks/useCurrentMapStatus.ts
+++ b/hooks/useCurrentMapStatus.ts
@@ -1,11 +1,13 @@
 import { useState } from 'react'
 
+import { INITIAL_MAP_STATE } from '@/constants/map'
 import { getCurrentMapStatus } from '@/lib/utils/map'
 import { MapState } from '@/types/map'
 
 export const useCurrentMapStatus = () => {
     const [currentMapState, setCurrentMapState] = useState<MapState>({
         level: 7,
+        center: INITIAL_MAP_STATE.center,
         swCoord: null,
         neCoord: null,
     })

--- a/hooks/useCurrentMapStatus.ts
+++ b/hooks/useCurrentMapStatus.ts
@@ -1,10 +1,15 @@
 import { useState } from 'react'
 
 import { INITIAL_MAP_STATE } from '@/constants/map'
-import { getCurrentMapStatus } from '@/lib/utils/map'
+import { getBoundedMapStatus } from '@/lib/utils/map'
 import { MapState } from '@/types/map'
 
-export const useCurrentMapStatus = () => {
+interface UseMapStatusProps {
+    isMapLoaded: boolean
+    map: kakao.maps.Map | null
+}
+
+export const useMapStatus = ({ isMapLoaded, map }: UseMapStatusProps) => {
     const [currentMapState, setCurrentMapState] = useState<MapState>({
         level: 7,
         center: INITIAL_MAP_STATE.center,
@@ -12,10 +17,11 @@ export const useCurrentMapStatus = () => {
         neCoord: null,
     })
 
-    const handleMapChange = (map: kakao.maps.Map) => {
-        const newMapStatus = getCurrentMapStatus(map)
-        setCurrentMapState(newMapStatus)
+    const updateMapStatus = () => {
+        if (!isMapLoaded || !map) return
+        // setCurrentMapState(getCurrentMapStatus(map))
+        setCurrentMapState(getBoundedMapStatus(map))
     }
 
-    return { currentMapState, handleMapChange }
+    return { currentMapState, updateMapStatus }
 }

--- a/lib/apis/cluster.ts
+++ b/lib/apis/cluster.ts
@@ -1,18 +1,30 @@
 import { httpClient } from '@/lib/apis/client'
+import { denormalizeCoordinate } from '@/lib/utils/normalize'
 import { MapState } from '@/types/map'
 
 export const clusterService = {
     // 뷰포트 영역 내 클러스터링 정보 조회
     // getClusteringInfo: async () => {
+    // {
+    //     // 줌레벨: 미터단위
+    //     1: 20000,   // 전국 단위
+    //     3: 15000,   // 도 단위
+    //     5: 10000,   // 시 단위
+    //     7: 5000,    // 구 단위
+    //     9: 2000,    // 동 단위
+    //     11: 1000,   // 상세 지역
+    //     13: 500,    // 매우 상세
+    //     14: 200     // 최대 줌
+    //   };
     getClusteringInfo: async ({ level, swCoord, neCoord }: MapState) => {
         if (!level || !swCoord || !neCoord) return
 
         const params = {
             level,
-            swLat: swCoord.lat,
-            swLng: swCoord.lng,
-            neLat: neCoord.lat,
-            neLng: neCoord.lng,
+            swLat: denormalizeCoordinate(swCoord.lat),
+            swLng: denormalizeCoordinate(swCoord.lng),
+            neLat: denormalizeCoordinate(neCoord.lat),
+            neLng: denormalizeCoordinate(neCoord.lng),
         }
         console.log(params)
         const response = await httpClient.get(`api/v1/vehicle/cluster`, {

--- a/lib/apis/cluster.ts
+++ b/lib/apis/cluster.ts
@@ -1,10 +1,10 @@
 import { httpClient } from '@/lib/apis/client'
 import { denormalizeCoordinate, getNormalizedZoomLevel } from '@/lib/utils/normalize'
-import { MapState } from '@/types/map'
+import { ClusterInfoModel, MapState } from '@/types/map'
 
 export const clusterService = {
     // 뷰포트 영역 내 클러스터링 정보 조회
-    getClusteringInfo: async ({ level, swCoord, neCoord }: MapState) => {
+    getClusterInfo: async ({ level, swCoord, neCoord }: MapState) => {
         if (!level || !swCoord || !neCoord) return
 
         const params = {
@@ -19,10 +19,14 @@ export const clusterService = {
             params,
         })
 
-        return response.data.result
+        const filteredClusterInfo = response.data.result?.filter(
+            (cluterInfo: ClusterInfoModel) => cluterInfo.coordinate,
+        )
+
+        return filteredClusterInfo
     },
     // 뷰포트 영역 내 클러스터링 정보(count)가 10 미만일 경우 전체 차량 정보 조회
-    getClusteringDetailInfo: async ({ level, swCoord, neCoord }: MapState) => {
+    getClusterDetailInfo: async ({ level, swCoord, neCoord }: MapState) => {
         if (!level || level > 9 || !swCoord || !neCoord) return
 
         const params = {

--- a/lib/apis/cluster.ts
+++ b/lib/apis/cluster.ts
@@ -1,0 +1,63 @@
+import { httpClient } from '@/lib/apis/client'
+import { MapState } from '@/types/map'
+
+export const clusterService = {
+    // 뷰포트 영역 내 클러스터링 정보 조회
+    // getClusteringInfo: async () => {
+    getClusteringInfo: async ({ level, swCoord, neCoord }: MapState) => {
+        if (!level || !swCoord || !neCoord) return
+
+        const params = {
+            level,
+            swLat: swCoord.lat,
+            swLng: swCoord.lng,
+            neLat: neCoord.lat,
+            neLng: neCoord.lng,
+        }
+        console.log(params)
+        const response = await httpClient.get(`api/v1/vehicle/cluster`, {
+            params,
+        })
+
+        // const response = await httpClient.get(`api/v1/vehicle/cluster`, {
+        //     params: {
+        //         level: 9,
+        //         neLat: 38650929,
+        //         neLng: 132286492,
+        //         swLat: 35519341,
+        //         swLng: 124703415,
+        //     },
+        // })
+
+        console.log(response.data.result)
+    },
+    // 뷰포트 영역 내 클러스터링 정보(count)가 10 미만일 경우 전체 차량 정보 조회
+    getClusteringDetailInfo: async () => {
+        // getClusteringDetailInfo: async ({ level, swCoord, neCoord }: MapState) => {
+        // if (!level || !swCoord || !neCoord) return
+
+        // const params = {
+        //     level,
+        //     swLat: swCoord.lat,
+        //     swLng: swCoord.lng,
+        //     neLat: neCoord.lat,
+        //     neLng: neCoord.lng,
+        // }
+
+        // const response = await httpClient.get(`api/v1/vehicle/cluster`, {
+        //     params,
+        // })
+
+        const response = await httpClient.get(`api/v1/vehicle/cluster/details`, {
+            params: {
+                level: 3,
+                neLat: 38650929,
+                neLng: 132286492,
+                swLat: 35519341,
+                swLng: 124703415,
+            },
+        })
+
+        console.log(response)
+    },
+}

--- a/lib/apis/cluster.ts
+++ b/lib/apis/cluster.ts
@@ -1,11 +1,12 @@
 import { httpClient } from '@/lib/apis/client'
-import { denormalizeCoordinate, getNormalizedZoomLevel } from '@/lib/utils/normalize'
-import { ClusterInfoModel, MapState } from '@/types/map'
+import { denormalizeCoordinate, getNormalizedZoomLevel, normalizeClusterResponse } from '@/lib/utils/normalize'
+import { ClusterPoint, MapState } from '@/types/map'
 
 export const clusterService = {
     // 뷰포트 영역 내 클러스터링 정보 조회
-    getClusterInfo: async ({ level, swCoord, neCoord }: MapState) => {
-        if (!level || !swCoord || !neCoord) return
+
+    getClusterInfo: async ({ level, swCoord, neCoord }: MapState): Promise<ClusterPoint[]> => {
+        if (!level || !swCoord || !neCoord) return []
 
         const params = {
             level: getNormalizedZoomLevel(level),
@@ -19,12 +20,13 @@ export const clusterService = {
             params,
         })
 
-        const filteredClusterInfo = response.data.result?.filter(
-            (cluterInfo: ClusterInfoModel) => cluterInfo.coordinate,
+        const normalizedClusterInfo = normalizeClusterResponse(response.data.result).filter(
+            (cluster) => cluster.count > 10, // TODO: 10 매직넘버 처리
         )
 
-        return filteredClusterInfo
+        return normalizedClusterInfo
     },
+
     // 뷰포트 영역 내 클러스터링 정보(count)가 10 미만일 경우 전체 차량 정보 조회
     getClusterDetailInfo: async ({ level, swCoord, neCoord }: MapState) => {
         if (!level || level > 9 || !swCoord || !neCoord) return
@@ -41,6 +43,8 @@ export const clusterService = {
             params,
         })
 
-        return response.data.result
+        const normalizedClusterInfo = normalizeClusterResponse(response.data.result)
+
+        return normalizedClusterInfo
     },
 }

--- a/lib/apis/cluster.ts
+++ b/lib/apis/cluster.ts
@@ -1,75 +1,42 @@
 import { httpClient } from '@/lib/apis/client'
-import { denormalizeCoordinate } from '@/lib/utils/normalize'
+import { denormalizeCoordinate, getNormalizedZoomLevel } from '@/lib/utils/normalize'
 import { MapState } from '@/types/map'
 
 export const clusterService = {
     // 뷰포트 영역 내 클러스터링 정보 조회
-    // getClusteringInfo: async () => {
-    // {
-    //     // 줌레벨: 미터단위
-    //     1: 20000,   // 전국 단위
-    //     3: 15000,   // 도 단위
-    //     5: 10000,   // 시 단위
-    //     7: 5000,    // 구 단위
-    //     9: 2000,    // 동 단위
-    //     11: 1000,   // 상세 지역
-    //     13: 500,    // 매우 상세
-    //     14: 200     // 최대 줌
-    //   };
     getClusteringInfo: async ({ level, swCoord, neCoord }: MapState) => {
         if (!level || !swCoord || !neCoord) return
 
         const params = {
-            level,
+            level: getNormalizedZoomLevel(level),
             swLat: denormalizeCoordinate(swCoord.lat),
             swLng: denormalizeCoordinate(swCoord.lng),
             neLat: denormalizeCoordinate(neCoord.lat),
             neLng: denormalizeCoordinate(neCoord.lng),
         }
-        console.log(params)
+
         const response = await httpClient.get(`api/v1/vehicle/cluster`, {
             params,
         })
 
-        // const response = await httpClient.get(`api/v1/vehicle/cluster`, {
-        //     params: {
-        //         level: 9,
-        //         neLat: 38650929,
-        //         neLng: 132286492,
-        //         swLat: 35519341,
-        //         swLng: 124703415,
-        //     },
-        // })
-
-        console.log(response.data.result)
+        return response.data.result
     },
     // 뷰포트 영역 내 클러스터링 정보(count)가 10 미만일 경우 전체 차량 정보 조회
-    getClusteringDetailInfo: async () => {
-        // getClusteringDetailInfo: async ({ level, swCoord, neCoord }: MapState) => {
-        // if (!level || !swCoord || !neCoord) return
+    getClusteringDetailInfo: async ({ level, swCoord, neCoord }: MapState) => {
+        if (!level || level > 9 || !swCoord || !neCoord) return
 
-        // const params = {
-        //     level,
-        //     swLat: swCoord.lat,
-        //     swLng: swCoord.lng,
-        //     neLat: neCoord.lat,
-        //     neLng: neCoord.lng,
-        // }
-
-        // const response = await httpClient.get(`api/v1/vehicle/cluster`, {
-        //     params,
-        // })
+        const params = {
+            level: getNormalizedZoomLevel(level),
+            swLat: denormalizeCoordinate(swCoord.lat),
+            swLng: denormalizeCoordinate(swCoord.lng),
+            neLat: denormalizeCoordinate(neCoord.lat),
+            neLng: denormalizeCoordinate(neCoord.lng),
+        }
 
         const response = await httpClient.get(`api/v1/vehicle/cluster/details`, {
-            params: {
-                level: 3,
-                neLat: 38650929,
-                neLng: 132286492,
-                swLat: 35519341,
-                swLng: 124703415,
-            },
+            params,
         })
 
-        console.log(response)
+        return response.data.result
     },
 }

--- a/lib/apis/vehicle.ts
+++ b/lib/apis/vehicle.ts
@@ -4,14 +4,6 @@ import { normalizeVehicleResponse } from '@/lib/utils/normalize'
 import { removeSpaces } from '@/lib/utils/string'
 import mockRoutesData from '@/mock/vehicle_route_data.json'
 
-// interface ClusteringModel {
-//     level: number
-//     neLat: number
-//     neLng: number
-//     swLat: number
-//     swLng: number
-// }
-
 export const vehicleService = {
     // 개별차량 검색 조회
     getVehicleInfo: async (vehicleNumber: string) => {
@@ -44,29 +36,6 @@ export const vehicleService = {
 
         return response.data.result
     },
-    // 지도 뷰포트 클러스터링 조회
-    getClusteringInfo: async () => {
-        // getClusteringInfo: async ({ level, neLat, neLng, swLat, swLng }: ClusteringModel) => {
-        const response = await httpClient.get(`api/v1/vehicle/cluster`, {
-            // params: {
-            //     level,
-            //     neLat,
-            //     neLng,
-            //     swLat,
-            //     swLng,
-            // },
-            params: {
-                level: 12,
-                neLat: 38650929,
-                neLng: 132286492,
-                swLat: 35519341,
-                swLng: 124703415,
-            },
-        })
-
-        console.log(response)
-    },
-
     // getVehicleRoutesData: async () => {
     // getVehicleRoutesData: async (vehicleId: string, startDate: DateTime, endDate: DateTime, interval = 60) => {
     fetchVehicleRoutesData: async () => {

--- a/lib/utils/map.ts
+++ b/lib/utils/map.ts
@@ -30,3 +30,22 @@ export const getMarkerColor = (count: number) => {
         inner: '#f41d4e80',
     }
 }
+
+export const getCurrentMapStatus = (map: kakao.maps.Map) => {
+    const level = map.getLevel()
+
+    const bounds = map.getBounds()
+    const swLat = bounds.getSouthWest().getLat()
+    const swLng = bounds.getSouthWest().getLng()
+    const neLat = bounds.getNorthEast().getLat()
+    const neLng = bounds.getNorthEast().getLng()
+
+    const swCoord = { swLat, swLng }
+    const neCoord = { neLat, neLng }
+
+    return {
+        level,
+        swCoord,
+        neCoord,
+    }
+}

--- a/lib/utils/map.ts
+++ b/lib/utils/map.ts
@@ -37,16 +37,20 @@ export const getCurrentMapStatus = (map: kakao.maps.Map): MapState => {
     const level = map.getLevel()
 
     const bounds = map.getBounds()
+    const centerLat = map.getCenter().getLat()
+    const centerLng = map.getCenter().getLng()
     const swLat = bounds.getSouthWest().getLat()
     const swLng = bounds.getSouthWest().getLng()
     const neLat = bounds.getNorthEast().getLat()
     const neLng = bounds.getNorthEast().getLng()
 
+    const center = { lat: centerLat, lng: centerLng }
     const swCoord = { lat: swLat, lng: swLng }
     const neCoord = { lat: neLat, lng: neLng }
 
     return {
         level,
+        center,
         swCoord,
         neCoord,
     }

--- a/lib/utils/map.ts
+++ b/lib/utils/map.ts
@@ -1,3 +1,4 @@
+import { MAP_BOUNDS } from '@/constants/map'
 import { MapState } from '@/types/map'
 
 export const convertCoordsToAddress = (lat: number, lng: number): Promise<string> => {
@@ -33,7 +34,7 @@ export const getMarkerColor = (count: number) => {
     }
 }
 
-export const getCurrentMapStatus = (map: kakao.maps.Map): MapState => {
+export const getMapStatus = (map: kakao.maps.Map): MapState => {
     const level = map.getLevel()
 
     const bounds = map.getBounds()
@@ -53,5 +54,39 @@ export const getCurrentMapStatus = (map: kakao.maps.Map): MapState => {
         center,
         swCoord,
         neCoord,
+    }
+}
+
+export const getBoundedMapStatus = (map: kakao.maps.Map): MapState => {
+    const mapState = getMapStatus(map)
+    const { swCoord, neCoord } = mapState
+
+    if (!swCoord || !neCoord) return mapState
+
+    const isOutOfBounds = {
+        sw: {
+            lat: swCoord.lat > MAP_BOUNDS.SW_LAT,
+            lng: swCoord.lng > MAP_BOUNDS.SW_LNG,
+        },
+        ne: {
+            lat: neCoord.lat < MAP_BOUNDS.NE_LAT,
+            lng: neCoord.lng < MAP_BOUNDS.NE_LNG,
+        },
+    }
+
+    const boundedCoords = {
+        sw: {
+            lat: isOutOfBounds.sw.lat ? swCoord.lat : MAP_BOUNDS.SW_LAT,
+            lng: isOutOfBounds.sw.lng ? swCoord.lng : MAP_BOUNDS.SW_LNG,
+        },
+        ne: {
+            lat: isOutOfBounds.ne.lat ? neCoord.lat : MAP_BOUNDS.NE_LAT,
+            lng: isOutOfBounds.ne.lng ? neCoord.lng : MAP_BOUNDS.NE_LNG,
+        },
+    }
+    return {
+        ...mapState,
+        swCoord: boundedCoords.sw,
+        neCoord: boundedCoords.ne,
     }
 }

--- a/lib/utils/map.ts
+++ b/lib/utils/map.ts
@@ -1,3 +1,5 @@
+import { MapState } from '@/types/map'
+
 export const convertCoordsToAddress = (lat: number, lng: number): Promise<string> => {
     const geocoder = new kakao.maps.services.Geocoder()
 
@@ -31,7 +33,7 @@ export const getMarkerColor = (count: number) => {
     }
 }
 
-export const getCurrentMapStatus = (map: kakao.maps.Map) => {
+export const getCurrentMapStatus = (map: kakao.maps.Map): MapState => {
     const level = map.getLevel()
 
     const bounds = map.getBounds()
@@ -40,8 +42,8 @@ export const getCurrentMapStatus = (map: kakao.maps.Map) => {
     const neLat = bounds.getNorthEast().getLat()
     const neLng = bounds.getNorthEast().getLng()
 
-    const swCoord = { swLat, swLng }
-    const neCoord = { neLat, neLng }
+    const swCoord = { lat: swLat, lng: swLng }
+    const neCoord = { lat: neLat, lng: neLng }
 
     return {
         level,

--- a/lib/utils/map.ts
+++ b/lib/utils/map.ts
@@ -1,6 +1,7 @@
 import { MAP_BOUNDS } from '@/constants/map'
 import { MapState } from '@/types/map'
 
+// 위도와 경도를 받아 해당 좌표의 주소를 반환
 export const convertCoordsToAddress = (lat: number, lng: number): Promise<string> => {
     const geocoder = new kakao.maps.services.Geocoder()
 
@@ -15,6 +16,7 @@ export const convertCoordsToAddress = (lat: number, lng: number): Promise<string
     })
 }
 
+// 마커의 개수에 따라 정해진 색상을 반환
 export const getMarkerColor = (count: number) => {
     if (count <= 100) {
         return {
@@ -34,6 +36,7 @@ export const getMarkerColor = (count: number) => {
     }
 }
 
+// 현재 지도의 상태(레벨, 중심좌표, 경계좌표)를 반환
 export const getMapStatus = (map: kakao.maps.Map): MapState => {
     const level = map.getLevel()
 
@@ -57,6 +60,8 @@ export const getMapStatus = (map: kakao.maps.Map): MapState => {
     }
 }
 
+// 지정된 경계 내로 제한된 지도 상태를 반환하는 함수
+// 현재 지도 상태가 지정된 경계를 벗어날 경우, 경계값으로 보정
 export const getBoundedMapStatus = (map: kakao.maps.Map): MapState => {
     const mapState = getMapStatus(map)
     const { swCoord, neCoord } = mapState

--- a/lib/utils/normalize.ts
+++ b/lib/utils/normalize.ts
@@ -1,7 +1,11 @@
+import { LatLng } from '@/types/location'
+import { ClusterInfoModel, ClusterPoint } from '@/types/map'
 import { VehicleInfoModel } from '@/types/vehicle'
 
 export const normalizeCoordinate = (coordinateValue: number): number => coordinateValue / 1000000
 export const denormalizeCoordinate = (coordinateValue: number): number => Math.round(coordinateValue * 1000000)
+
+export const getNormalizedZoomLevel = (level: number) => (level % 2 === 0 ? level - 1 : level)
 
 export const normalizeVehicleResponse = (data: VehicleInfoModel) => {
     return {
@@ -14,4 +18,20 @@ export const normalizeVehicleResponse = (data: VehicleInfoModel) => {
     }
 }
 
-export const getNormalizedZoomLevel = (level: number) => (level % 2 === 0 ? level - 1 : level)
+export const normalizeClusterResponse = (data: ClusterInfoModel[]) => {
+    const filteredClusterInfo = data?.filter(
+        (clusterInfo): clusterInfo is ClusterInfoModel & { coordinate: LatLng } => clusterInfo.coordinate !== null,
+    )
+
+    const normalizedClusterInfo = filteredClusterInfo.map((clusterInfo: ClusterPoint) => {
+        return {
+            ...clusterInfo,
+            coordinate: {
+                lat: normalizeCoordinate(clusterInfo.coordinate.lat),
+                lng: normalizeCoordinate(clusterInfo.coordinate.lng),
+            },
+        }
+    })
+
+    return normalizedClusterInfo
+}

--- a/lib/utils/normalize.ts
+++ b/lib/utils/normalize.ts
@@ -1,7 +1,7 @@
 import { VehicleInfoModel } from '@/types/vehicle'
 
 export const normalizeCoordinate = (coordinateValue: number): number => coordinateValue / 1000000
-export const denormalizeCoordinate = (coordinateValue: number): number => coordinateValue * 1000000
+export const denormalizeCoordinate = (coordinateValue: number): number => Math.round(coordinateValue * 1000000)
 
 export const normalizeVehicleResponse = (data: VehicleInfoModel) => {
     return {

--- a/lib/utils/normalize.ts
+++ b/lib/utils/normalize.ts
@@ -13,3 +13,5 @@ export const normalizeVehicleResponse = (data: VehicleInfoModel) => {
         },
     }
 }
+
+export const getNormalizedZoomLevel = (level: number) => (level % 2 === 0 ? level - 1 : level)

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -43,7 +43,7 @@ export const validateEmail = (email: string) => {
     }
 
     // TODO: 추후 삭제!
-    if (email === 'string') {
+    if (email === 'string' || email === 'test1') {
         return {
             isValid: true,
             value: email,

--- a/types/map.ts
+++ b/types/map.ts
@@ -2,9 +2,11 @@ import { ZOOM_LEVEL } from '@/constants/map'
 import { LatLng } from '@/types/location'
 
 export interface MapState {
-    center: LatLng
     // level: (typeof ZOOM_LEVEL)[keyof typeof ZOOM_LEVEL]
     level: number
+    center?: LatLng
+    swCoord?: LatLng | null
+    neCoord?: LatLng | null
 }
 
 export type ZoomLevelValueType = (typeof ZOOM_LEVEL)[keyof typeof ZOOM_LEVEL]

--- a/types/map.ts
+++ b/types/map.ts
@@ -10,3 +10,15 @@ export interface MapState {
 }
 
 export type ZoomLevelValueType = (typeof ZOOM_LEVEL)[keyof typeof ZOOM_LEVEL]
+
+// 서버 응답 클러스터링 데이터
+export interface ClusterInfoModel {
+    coordinate: LatLng | null
+    count: number
+}
+
+// 필터링된 클러스터링 데이터 (coordinate: null 제외)
+export interface ClusterPoint {
+    coordinate: LatLng
+    count: number
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- closes #issue-number -->

closes #98

## 📋 작업 내용

### 1. 지도 컴포넌트 초기화 및 인스턴스 타이밍 관리 개선

- react-kakao-maps-sdk의 로딩과 맵 인스턴스 생성 시점 불일치 문제 해결
  - Map 컴포넌트의 `loading`과 `onCreate` 이벤트 타이밍 차이로 인한 `ref.current`가 `undefined`이 되는 문제 해결
  - 안정적인 맵 인스턴스 참조를 위한 상태 관리 로직 개선

### 2. 동적 지도 상태 관리 구현

- 사용자 인터랙션에 따른 지도 상태 업데이트 로직 구현
  - `onZoomChanged` 이벤트를 사용해, 줌 레벨 변경 시 클러스터링 데이터 갱신
  - `onDragEnd` 이벤트를 사용해, 지도 이동 완료 시점에 경계범위 정보 업데이트

### 3. 클러스터링 API 연동

- 지도 상태에 따른 계층적 클러스터링 데이터 조회 구현
  - 기본 클러스터링 정보 조회 API 연동
  - 상세 정보 조회 로직 구현 (뷰포트 내 10대 미만 케이스 처리)
  - 응답 데이터 정규화 및 좌표 변환 처리

### 4. 지도 상태 관리 유틸리티 구현

- `getMapStatus`: 현재 지도의 뷰포트 내 메타 정보(레벨, 중심좌표, 경계) 추출
- `getBoundedMapStatus`: 지정된 경계 내로 제한된 지도 상태 반환
- `getNormalizedZoomLevel`: API 스펙에 맞는 줌레벨 정규화 (3,5,7,9,11,13)
- `normalizeClusterResponse:` null 좌표 필터링 및 위경도 포맷 변환

## 🔧 변경 사항

- [x] 💡 비즈니스 로직 (src/, app/ 등)
- [ ] 📦 의존성 (package.json)
- [ ] 📃 문서 (README.md 등)
- [ ] 🔥 삭제된 파일/코드
- [ ] ⚙️ 설정 파일 (.env, .gitignore 등)

## 📸 스크린샷

https://github.com/user-attachments/assets/5d1d8d04-973d-4e9f-bcc7-97ee2d857b15

## 📄 기타

### 향후 개선 사항

1. 터치패드 사용성 개선
  - 현재 `onDragEnd` 이벤트의 터치패드 반응성 이슈 존재
  - `onCenterChanged` 또는 `onBoundsChanged` 이벤트로 전환 검토
  - 디바운스/쓰로틀링 적용하여 성능 최적화 예정

2. 클러스터링 데이터 처리 개선
  - 서버 응답 데이터 이슈
  - 서버 내 계산 로직 개선 후 클라이언트 최적화 작업 진행 예정