### PR TITLE
[Fix] 미들웨어 인증 로직 개선

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,17 +2,19 @@ import { NextRequest, NextResponse } from 'next/server'
 
 export const middleware = async (request: NextRequest) => {
     const accessToken = request.cookies.get('access_token')
+    const refreshToken = request.cookies.get('refresh_token')
 
     const { pathname } = request.nextUrl
 
     console.log('----------------------------------------------')
     console.log('액세스 토큰: ', accessToken)
+    console.log('리프레시 토큰: ', refreshToken)
     console.log('----------------------------------------------')
 
     const protectedRoutes = ['/dashboard', '/log', '/route', '/location']
 
     if (protectedRoutes.some((route) => pathname.startsWith(route))) {
-        if (!accessToken) {
+        if (!accessToken && !refreshToken) {
             return NextResponse.redirect(new URL('/signin', request.url))
         }
     }

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,7 +19,7 @@ export const middleware = async (request: NextRequest) => {
         }
     }
 
-    if (pathname === '/signin' && accessToken) {
+    if (pathname === '/signin' && (accessToken || refreshToken)) {
         return NextResponse.redirect(new URL('/dashboard', request.url))
     }
 


### PR DESCRIPTION
- 기존: 액세스 토큰 체크만 진행
- 변경: 액세스 + 리프레시 토큰 둘 다 체크

# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- closes #issue-number -->

## 📋 작업 내용

- 미들웨어 인증 로직 개선
- 액세스 토큰 만료 시, API 요청이 아닌 페이지 요청 시 미들웨어에서 로그인 페이지로 이동시키는 문제
  - 기존: 액세스 토큰 체크만 진행
  - 변경: 액세스 + 리프레시 토큰 둘 다 체크
